### PR TITLE
Add Nix flake, devShell and NixOS module for deployment

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,1 @@
+use flake

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,5 @@ image/
 *.old
 custom/*
 !custom/.gitkeep
+.direnv/
+result*

--- a/db.js
+++ b/db.js
@@ -1,5 +1,6 @@
 let sqlite3 = require('sqlite3');
 const fs = require('fs')
+const path = require('path');
 const geolib = require('geolib');
 
 module.exports.REGTYPE_TOKEN = "token";
@@ -10,10 +11,10 @@ module.exports.Config = class Config {
     constructor() {
         if (!fs.existsSync("config.json")) {
             console.error("Config not found! Copying standard config file. Please adjust.");
-            fs.copyFileSync("config.json.template", "config.json")
+            fs.copyFileSync(path.resolve(__dirname, "config.json.template"), "config.json")
         }
         this.config = JSON.parse(fs.readFileSync("config.json").toString());
-        this.defaultConfig = JSON.parse(fs.readFileSync("config.json.template").toString());
+        this.defaultConfig = JSON.parse(fs.readFileSync(path.resolve(__dirname, "config.json.template")).toString());
     }
 
     registrationEnabled(regType) {
@@ -204,4 +205,3 @@ module.exports.SQLite = class SQLite {
         }.bind(this))
     }
 }
-

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,80 @@
+{
+  "nodes": {
+    "flake-parts": {
+      "inputs": {
+        "nixpkgs-lib": "nixpkgs-lib"
+      },
+      "locked": {
+        "lastModified": 1706830856,
+        "narHash": "sha256-a0NYyp+h9hlb7ddVz4LUn1vT/PLwqfrWYcHMvFB1xYg=",
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "rev": "b253292d9c0a5ead9bc98c4e9a26c6312e27d69f",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1706925685,
+        "narHash": "sha256-hVInjWMmgH4yZgA4ZtbgJM1qEAel72SYhP5nOWX4UIM=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "79a13f1437e149dc7be2d1290c74d378dad60814",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs-lib": {
+      "locked": {
+        "dir": "lib",
+        "lastModified": 1706550542,
+        "narHash": "sha256-UcsnCG6wx++23yeER4Hg18CXWbgNpqNXcHIo5/1Y+hc=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "97b17f32362e475016f942bbdfda4a4a72a8a652",
+        "type": "github"
+      },
+      "original": {
+        "dir": "lib",
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-parts": "flake-parts",
+        "nixpkgs": "nixpkgs",
+        "systems": "systems"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,45 @@
+{
+  description = "A location finding game.";
+
+  inputs = {
+    nixpkgs.url = "github:nixos/nixpkgs/nixpkgs-unstable";
+    flake-parts.url = "github:hercules-ci/flake-parts";
+    systems.url = "github:nix-systems/default";
+  };
+
+  outputs = inputs: inputs.flake-parts.lib.mkFlake { inherit inputs; } {
+    systems = import inputs.systems;
+    imports = [ ];
+
+    perSystem = { self', pkgs, lib, ... }: {
+      devShells.default = pkgs.mkShellNoCC {
+        packages = [
+          pkgs.nodejs_21
+          pkgs.prefetch-npm-deps
+        ];
+      };
+
+      packages.default = pkgs.buildNpmPackage rec {
+        pname = "locsearch";
+        version = "1.0.0";
+
+        src = inputs.self;
+
+        npmDepsHash = "sha256-+WqYKAWF/V/lVhy72IDwhT0Do/LVcw99sB/Wj1KLv/Y=";
+
+        dontNpmBuild = true;  # this doesn't have a build script
+
+        meta = {
+          description = "A location finding game.";
+          homepage = "https://github.com/strifel/locSearch";
+          license = lib.licenses.mit;
+        };
+      };
+      apps.default = {
+        type = "app";
+        program = "${self'.packages.default}/bin/locsearch";
+      };
+    };
+    flake.nixosModules.default = import ./nixos-module.nix inputs.self;
+  };
+}

--- a/main.js
+++ b/main.js
@@ -10,6 +10,7 @@ var config = new dbManager.Config();
 var db = new dbManager.SQLite();
 const auth = require('./auth');
 const frontend = require('./frontend')
+const path = require('path');
 auth.db = db;
 app.use('/static', express.static('web/static'));
 app.use('/static', express.static('custom'));
@@ -17,7 +18,7 @@ app.use('/image', express.static('image'));
 app.use(express.static('public'));
 app.use(bodyParser.json());
 app.use(cookies())
-app.set('views', './web/templates');
+app.set('views', path.resolve(__dirname, 'web/templates'));
 frontend.registerRoutes(app, db, auth, config, game);
 
 

--- a/nixos-module.nix
+++ b/nixos-module.nix
@@ -1,0 +1,31 @@
+self:
+
+{ pkgs, lib, config, ... }:
+
+{
+  options.services.locsearch = {
+    enable = lib.mkEnableOption (lib.mdDoc "locsearch, a location finding game.");
+    package = lib.mkOption {
+      description = "The locsearch package to use.";
+      type = lib.types.package;
+      default = self.packages.${pkgs.hostPlatform.system}.default;
+    };
+  };
+
+  config = let
+    cfg = config.services.locsearch;
+  in lib.mkIf cfg.enable {
+    systemd.services.locsearch = {
+      description = "locsearch";
+      wantedBy = [ "multi-user.target" ];
+      after = [ "networking.target" ];
+      serviceConfig = {
+        DynamicUser = true;
+        StateDirectory = "locsearch";
+        WorkingDirectory = "/var/lib/private/locsearch";
+        ExecStart = "${cfg.package}/bin/locsearch";
+        Restart = "always";
+      };
+    };
+  };
+}

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "run": "node .",
     "setupImage": "node setUpImageSearch.js"
   },
+  "bin": "./main.js",
   "keywords": [],
   "author": "strifel",
   "license": "MIT",

--- a/setUpImageSearch.js
+++ b/setUpImageSearch.js
@@ -1,6 +1,7 @@
 const express = require('express');
 const dbManager = require('./db');
 const fs = require('fs');
+const path = require('path');
 const Twig = require("twig");
 const bodyParser = require('body-parser');
 const exifr = require('exifr')
@@ -12,7 +13,7 @@ let config = new dbManager.Config();
 app.use('/image', express.static('image'));
 app.use(bodyParser.urlencoded());
 
-app.set('views', './web/templates');
+app.set('views', path.resolve(__dirname, 'web/templates'));
 
 
 let files = fs.readdirSync("image/");


### PR DESCRIPTION
This adds a Nix flake with
- a devShell with Node 21 so you can develop it without a global Node installation
- a Nix package with the app
- a (very minimal) NixOS module for deploying it.

It also fixes that the app assumes to be run in the repo as current working directory and uses `__dirname` instead.