### PR TITLE
Use dirname for static paths from package

### DIFF
--- a/main.js
+++ b/main.js
@@ -12,10 +12,10 @@ const auth = require('./auth');
 const frontend = require('./frontend')
 const path = require('path');
 auth.db = db;
-app.use('/static', express.static('web/static'));
+app.use('/static', express.static(path.resolve(__dirname, 'web/static')));
 app.use('/static', express.static('custom'));
 app.use('/image', express.static('image'));
-app.use(express.static('public'));
+app.use(express.static(path.resolve(__dirname, 'public')));
 app.use(bodyParser.json());
 app.use(cookies())
 app.set('views', path.resolve(__dirname, 'web/templates'));


### PR DESCRIPTION
I missed some static paths served from the repo that didn't use `__dirname` yet in #13. The other two static paths, `custom` and `image` are supposed to be user-supplied if I understand correctly, so I left them to be loaded from the cwd.